### PR TITLE
Use `mermaid` for classDiagram

### DIFF
--- a/docs/cards.md
+++ b/docs/cards.md
@@ -151,13 +151,9 @@ markdown_extensions:
 
 ### Schema
 
-```plantuml
-@startuml "Cards"
-
-!theme plain
-
-left to right direction
-hide empty members
+```mermaid
+classDiagram
+direction LR
 
 class CardItem {
     title: str
@@ -174,7 +170,6 @@ class Cards {
 
 Cards --> CardItem
 
-@enduml
 ```
 
 ```python

--- a/docs/gantt.md
+++ b/docs/gantt.md
@@ -25,7 +25,6 @@ markdown_extensions:
 
 ### Examples
 
-
 === "JSON"
 
     ```json
@@ -169,13 +168,9 @@ markdown_extensions:
 The input for a Gantt diagram is a list of activities having a shape described
 by the following scheme:
 
-```plantuml
-@startuml "Timeline"
-
-!theme plain
-
-left to right direction
-hide empty members
+```mermaid
+classDiagram
+direction LR
 
 class Event {
     title: str
@@ -197,7 +192,6 @@ class Activity {
 Activity --> Event
 Activity --> Activity
 
-@enduml
 ```
 
 ```python

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -104,13 +104,9 @@ markdown_extensions:
 
 ### Schema
 
-```plantuml
-@startuml "Timeline"
-
-!theme plain
-
-left to right direction
-hide empty members
+```mermaid
+classDiagram
+direction LR
 
 class TimelineItem {
     title: str
@@ -124,10 +120,8 @@ class Timeline {
     items: Array of TimelineItem
 }
 
-
 Timeline --> TimelineItem
 
-@enduml
 ```
 
 ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,11 +75,13 @@ markdown_extensions:
   - pymdownx.magiclink
   - pymdownx.mark
   - pymdownx.smartsymbols
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tabbed:
       alternate_style: true
   - footnotes
-  - plantuml_markdown:
-      server: http://www.plantuml.com/plantuml

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ neoteroi-mkdocs
 oauthlib==3.2.0
 packaging==21.3
 pathspec==0.9.0
-plantuml-markdown==3.6.3
 platformdirs==2.5.2
 pycparser==2.21
 Pygments==2.12.0


### PR DESCRIPTION
`mermaid` is already built-in of Material for MkDocs theme. Using the mermaid's [classDiagram](https://mermaid.js.org/syntax/classDiagram.html) makes the classDiagram look better in dark mode too. This also allows to remove `plantuml-markdown` dependency. 

**Before**
![image](https://github.com/Neoteroi/mkdocs-plugins-docs/assets/95703687/deb5febb-ba7f-4787-887e-77038557196c)

**After**

![image](https://github.com/Neoteroi/mkdocs-plugins-docs/assets/95703687/48707ea9-2796-4ebf-8d70-6086a3576fe3)

